### PR TITLE
chore(windows): add TL;DR installation section to media.md

### DIFF
--- a/windows/media.md
+++ b/windows/media.md
@@ -11,6 +11,29 @@ Complete workflow from recording to publishing:
 4. **Video Editing** - Compositing and final assembly
 5. **Publishing** - Export and upload to YouTube/Instagram
 
+## TL;DR - Software Installation
+
+```powershell
+# Video recording
+winget install -e --id OBSProject.OBSStudio
+
+# Video editor
+winget install -e --id KDE.kdenlive
+# Alternative: DaVinci Resolve (more stable on Windows)
+
+# Notation software
+winget install -e --id Musescore.Musescore
+
+# Backing track downloader (requires ffmpeg for audio conversion)
+scoop install yt-dlp ffmpeg
+```
+
+**Manual downloads (required):**
+- **Focusrite drivers** - https://focusrite.com (includes ASIO drivers) - **reboot after install**
+- **Ableton Live Lite** - Bundled with Scarlett (serial key in Focusrite account)
+- **MeldaProduction Free Bundle** - https://meldaproduction.com/MFreeFXBundle
+  - Install to: `C:\Program Files\VstPlugins\MeldaProduction`
+
 ## Hardware Setup
 
 ### Audio Interface


### PR DESCRIPTION
## Summary
- Add quick installation overview at the top of media workflow documentation
- Consolidate winget commands for easy copy-paste (OBS, kdenlive, MuseScore)
- Use scoop for yt-dlp/ffmpeg (consistent with setup.md conventions)
- Make URLs clickable with https:// prefix
- Separate manual downloads into clear, focused section

## Test plan
- [ ] Verify all winget package IDs are correct
- [ ] Verify scoop packages (yt-dlp, ffmpeg) install successfully
- [ ] Check that URLs are clickable in rendered markdown
- [ ] Confirm installation flow matches actual usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)